### PR TITLE
Contact Us Page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,6 +2,19 @@ logo: /images/pc_2020_may_11_v1.png
 links:
   - title: Who We Are
     collection: who-we-are
+  - title: New menu group
+    url: /permalink
+    sublinks:
+      - title: What We Do
+        url: /who-we-are/what-we-do
+      - title: Milestones
+        url: /who-we-are/milestones
+      - title: PC Social Enterprise Awards
+        url: /who-we-are/social-enterprise
+      - title: Events
+        url: /who-we-are/events
+      - title: Contact Us
+        url: /contact-us
   - title: Who We Support
     url: /whowesupport
   - title: Take Action

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,5 @@
 logo: /images/pc_2020_may_11_v1.png
 links:
-  - title: Who We Are
-    collection: who-we-are
   - title: New menu group
     url: /permalink
     sublinks:

--- a/_who-we-are/collection.yml
+++ b/_who-we-are/collection.yml
@@ -6,4 +6,3 @@ collections:
       - milestones.md
       - pc-social-enterprise-awards.md
       - events.md
-      - contact-us.md

--- a/_who-we-are/contact-us.md
+++ b/_who-we-are/contact-us.md
@@ -1,8 +1,0 @@
----
-layout: contact_us
-title: 'Contact Us'
-permalink: /who-we-are/contact-us/
-breadcrumb: 'Contact Us'
-
----
-


### PR DESCRIPTION
Streamline Contact Us into one instead of the current 2 pages. 
- /who-we-are/contact-us/
- /contact-us (keeping this as the only page)